### PR TITLE
Update kruscal to work with union_find

### DIFF
--- a/content/graphs/kruskal.cpp
+++ b/content/graphs/kruskal.cpp
@@ -1,29 +1,29 @@
 /*
  *Description:* Minimum spanning tree in $O(E log E)$
- *Status:* Tested, but needs to be re-written
-*/struct Edge {
+ *Status:* Tested
+*/
+struct Edge {
   int a; int b; int w;
   Edge(int a_, int b_, int w_) : a(a_), b(b_), w(w_) {}
-}
-bool c_edge(Edge &a, Edge &b) { return a.w < b.w;  }
+};
+bool c_edge(Edge &a, Edge &b) { return a.w < b.w; }
 int Kruskal() {
   int n = G.size();
-  UnionFind sets(n);
+  union_find sets(n);
   vector< Edge > edges;
   for(int i = 0; i < n; i++) {
-    for(pi eg : G[i]) {
+    for(auto eg : G[i]) {
       // node i to node eg.first with cost eg.second
-      Edge e(i, eg.first, eg.second);
-      edges.push_back(e);
+      edges.emplace_back(i, eg.first, eg.second);
     }
   }
   sort(edges.begin(), edges.end(), c_edge);
   int min_cost = 0;
-  for(Edge e : Edges) {
-    if(sets.find(e.a, e.b) != true) {
-      tree.push_back(Edge(e.a, e.b, e.w));
+  for(Edge e : edges) {
+    if(sets.sameSet(e.a, e.b) != true) {
+      tree.emplace_back(e.a, e.b, e.w);
       min_cost += e.w;
-      sets.union(e.a, e.b);
+      sets.unionSet(e.a, e.b);
     }
   }
   return min_cost;


### PR DESCRIPTION
Kruscal now match with the implementation of union_find and uses emplace_back to micro optimization, because it doesn't need to copy the object in the function push_back of vector library, creating the object inside.