### PR TITLE
fix: use long long in hash and power vectors

### DIFF
--- a/content/strings/rolling-hashing.cpp
+++ b/content/strings/rolling-hashing.cpp
@@ -5,7 +5,7 @@
 template<class T>
 struct rolling_hashing {
   int base, mod; 
-  vector<int> p, H;
+  vector<long long> p, H;
   int n;
   rolling_hashing(const T &s, int b, int m): base(b), mod(m), n(s.size()) {
     p.assign(n+1, 1);


### PR DESCRIPTION
Many people who don't use `#define int long long` were getting a wrong answer with this template.