### PR TITLE
FFT convMod() fix SegFault

### DIFF
--- a/content/maths/fft.cpp
+++ b/content/maths/fft.cpp
@@ -60,7 +60,7 @@ struct FFT {
       res[i] = ((av % mod * cut + bv) % mod * cut + cv) % mod;
     }
     vector<int> resint(res.size());
-    for (int i = 0; i < n; i++) resint[i] = round(res[i]);
+    for (int i = 0; i < res.size(); i++) resint[i] = round(res[i]);
     return resint;
   }
 };


### PR DESCRIPTION
Arreglo de la función convMod de SegFault al pasar el vector res a resint.

Problema: https://codeforces.com/problemset/problem/958/F3
Solución: https://codeforces.com/contest/958/submission/331520186
