### PR TITLE
fix: remove pull_request trigger from compile-pdf workflow

### DIFF
--- a/.github/workflows/compile-handbook.yml
+++ b/.github/workflows/compile-handbook.yml
@@ -3,8 +3,6 @@ name: compile-pdf
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   setup:


### PR DESCRIPTION
Run the job (`compile-handbook`) on pull requests is unnecessary, because the release should be created once the change has been accepted.
