### PR TITLE
fix: correct latest version release

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -28,8 +28,8 @@ jobs:
       id: create_release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: v1.0.${{ github.run_number }}
-        name: "Release v1.0.${{ github.run_number }}"
+        tag_name: v1.1.${{ github.run_number }}
+        name: "Release v1.1.${{ github.run_number }}"
         generate_release_notes: true
         files: main.pdf
       env:


### PR DESCRIPTION
Maybe in the future we can create a date-based versioning format or something that doesn't cause this error.